### PR TITLE
Rename time attributes on binned time series

### DIFF
--- a/astropy_timeseries/binned.py
+++ b/astropy_timeseries/binned.py
@@ -123,18 +123,30 @@ class BinnedTimeSeries(BaseTimeSeries):
 
     @property
     def time_bin_start(self):
+        """
+        The start times of all the time bins.
+        """
         return self['time_bin_start']
 
     @property
     def time_bin_center(self):
+        """
+        The center times of all the time bins.
+        """
         return self['time_bin_start'] + self['time_bin_size'] * 0.5
 
     @property
     def time_bin_end(self):
+        """
+        The end times of all the time bins.
+        """
         return self['time_bin_start'] + self['time_bin_size']
 
     @property
     def time_bin_size(self):
+        """
+        The sizes of all the time bins.
+        """
         return self['time_bin_size']
 
     def __getitem__(self, item):

--- a/astropy_timeseries/binned.py
+++ b/astropy_timeseries/binned.py
@@ -18,8 +18,8 @@ class BinnedTimeSeries(BaseTimeSeries):
 
     _require_time_column = False
 
-    def __init__(self, data=None, start_time=None, end_time=None,
-                 bin_size=None, n_bins=None, **kwargs):
+    def __init__(self, data=None, time_bin_start=None, time_bin_end=None,
+                 time_bin_size=None, n_bins=None, **kwargs):
 
         super().__init__(data=data, **kwargs)
 
@@ -27,115 +27,119 @@ class BinnedTimeSeries(BaseTimeSeries):
         # to be created, then columns added one by one. We should check that
         # when columns are added manually, time is added first and is of the
         # right type.
-        if (data is None and start_time is None and end_time is None and
-                bin_size is None and n_bins is None):
-            self._required_columns = ['start_time', 'bin_size']
+        if (data is None and time_bin_start is None and time_bin_end is None and
+                time_bin_size is None and n_bins is None):
+            self._required_columns = ['time_bin_start', 'time_bin_size']
             return
 
-        # First if start_time and end_time have been given in the table data, we
+        # First if time_bin_start and time_bin_end have been given in the table data, we
         # should extract them and treat them as if they had been passed as
         # keyword arguments.
 
-        if 'start_time' in self.colnames:
-            if start_time is None:
-                start_time = self.columns['start_time']
-                self.remove_column('start_time')
+        if 'time_bin_start' in self.colnames:
+            if time_bin_start is None:
+                time_bin_start = self.columns['time_bin_start']
+                self.remove_column('time_bin_start')
             else:
-                raise TypeError("'start_time' has been given both in the table "
+                raise TypeError("'time_bin_start' has been given both in the table "
                                 "and as a keyword argument")
 
-        if 'bin_size' in self.colnames:
-            if bin_size is None:
-                bin_size = self.columns['bin_size']
-                self.remove_column('bin_size')
+        if 'time_bin_size' in self.colnames:
+            if time_bin_size is None:
+                time_bin_size = self.columns['time_bin_size']
+                self.remove_column('time_bin_size')
             else:
-                raise TypeError("'bin_size' has been given both in the table "
+                raise TypeError("'time_bin_size' has been given both in the table "
                                 "and as a keyword argument")
 
-        if start_time is None:
-            raise TypeError("'start_time' has not been specified")
+        if time_bin_start is None:
+            raise TypeError("'time_bin_start' has not been specified")
 
-        if end_time is None and bin_size is None:
-            raise TypeError("Either 'bin_size' or 'end_time' should be specified")
+        if time_bin_end is None and time_bin_size is None:
+            raise TypeError("Either 'time_bin_size' or 'time_bin_end' should be specified")
 
-        if not isinstance(start_time, Time):
-            start_time = Time(start_time)
+        if not isinstance(time_bin_start, Time):
+            time_bin_start = Time(time_bin_start)
 
-        if end_time is not None and not isinstance(end_time, Time):
-            end_time = Time(end_time)
+        if time_bin_end is not None and not isinstance(time_bin_end, Time):
+            time_bin_end = Time(time_bin_end)
 
-        if bin_size is not None and not isinstance(bin_size, (Quantity, TimeDelta)):
-            raise TypeError("'bin_size' should be a Quantity or a TimeDelta")
+        if time_bin_size is not None and not isinstance(time_bin_size, (Quantity, TimeDelta)):
+            raise TypeError("'time_bin_size' should be a Quantity or a TimeDelta")
 
-        if isinstance(bin_size, TimeDelta):
-            bin_size = bin_size.sec * u.s
+        if isinstance(time_bin_size, TimeDelta):
+            time_bin_size = time_bin_size.sec * u.s
 
-        if start_time.isscalar:
+        if time_bin_start.isscalar:
 
             # We interpret this as meaning that this is the start of the
             # first bin and that the bins are contiguous. In this case,
-            # we require bin_size to be specified.
+            # we require time_bin_size to be specified.
 
-            if bin_size is None:
-                raise TypeError("'start_time' is scalar, so 'bin_size' is required")
+            if time_bin_size is None:
+                raise TypeError("'time_bin_start' is scalar, so 'time_bin_size' is required")
 
-            if bin_size.isscalar:
+            if time_bin_size.isscalar:
 
                 if data is not None:
                     # TODO: raise error if also passed explicily and inconsistent
                     n_bins = len(self)
 
-                bin_size = np.repeat(bin_size, n_bins)
+                time_bin_size = np.repeat(time_bin_size, n_bins)
 
-            time_delta = np.cumsum(bin_size)
-            end_time = start_time + time_delta
+            time_delta = np.cumsum(time_bin_size)
+            time_bin_end = time_bin_start + time_delta
 
             # Now shift the array so that the first entry is 0
             time_delta = np.roll(time_delta, 1)
             time_delta[0] = 0. * u.s
 
-            # Make start_time into an array
-            start_time = start_time + time_delta
+            # Make time_bin_start into an array
+            time_bin_start = time_bin_start + time_delta
 
         else:
 
-            if len(self.colnames) > 0 and len(start_time) != len(self):
-                raise ValueError("Length of 'start_time' ({0}) should match "
-                                 "table length ({1})".format(len(start_time), len(self)))
+            if len(self.colnames) > 0 and len(time_bin_start) != len(self):
+                raise ValueError("Length of 'time_bin_start' ({0}) should match "
+                                 "table length ({1})".format(len(time_bin_start), len(self)))
 
-            if end_time is not None:
-                if end_time.isscalar:
-                    times = start_time.copy()
+            if time_bin_end is not None:
+                if time_bin_end.isscalar:
+                    times = time_bin_start.copy()
                     times[:-1] = times[1:]
-                    times[-1] = end_time
-                    end_time = times
-                bin_size = (end_time - start_time).sec * u.s
-            elif bin_size is None:
-                raise TypeError("Either 'bin_size' or 'end_time' should be specified")
+                    times[-1] = time_bin_end
+                    time_bin_end = times
+                time_bin_size = (time_bin_end - time_bin_start).sec * u.s
+            elif time_bin_size is None:
+                raise TypeError("Either 'time_bin_size' or 'time_bin_end' should be specified")
 
-        self.add_column(start_time, index=0, name='start_time')
-        self.add_index('start_time')
+        self.add_column(time_bin_start, index=0, name='time_bin_start')
+        self.add_index('time_bin_start')
 
-        if bin_size.isscalar:
-            bin_size = np.repeat(bin_size, len(self))
+        if time_bin_size.isscalar:
+            time_bin_size = np.repeat(time_bin_size, len(self))
 
-        self.add_column(bin_size, index=1, name='bin_size')
-
-    @property
-    def start_time(self):
-        return self['start_time']
+        self.add_column(time_bin_size, index=1, name='time_bin_size')
 
     @property
-    def end_time(self):
-        return self['start_time'] + self['bin_size']
+    def time_bin_start(self):
+        return self['time_bin_start']
 
     @property
-    def centre_time(self):
-        return self['start_time'] + self['bin_size'] * 0.5
+    def time_bin_center(self):
+        return self['time_bin_start'] + self['time_bin_size'] * 0.5
+
+    @property
+    def time_bin_end(self):
+        return self['time_bin_start'] + self['time_bin_size']
+
+    @property
+    def time_bin_size(self):
+        return self['time_bin_size']
 
     def __getitem__(self, item):
         if self._is_list_or_tuple_of_str(item):
-            if 'start_time' not in item or 'bin_size' not in item:
+            if 'time_bin_start' not in item or 'time_bin_size' not in item:
                 out = QTable([self[x] for x in item],
                              meta=deepcopy(self.meta),
                              copy_indices=self._copy_indices)

--- a/astropy_timeseries/downsample.py
+++ b/astropy_timeseries/downsample.py
@@ -19,7 +19,7 @@ def reduceat(array, indices, function):
     return np.array(result)
 
 
-def simple_downsample(time_series, bin_size, func=None, start_time=None, n_bins=None):
+def simple_downsample(time_series, time_bin_size, func=None, time_bin_start=None, n_bins=None):
     """
     Downsample a time series by binning values into bins with a fixed size,
     using a single function
@@ -28,12 +28,12 @@ def simple_downsample(time_series, bin_size, func=None, start_time=None, n_bins=
     ----------
     time_series : :class:`~astropy_timeseries.TimeSeries`
         The time series to downsample.
-    bin_size : `~astropy.units.Quantity`
+    time_bin_size : `~astropy.units.Quantity`
         The time interval for the binned time series
     func : callable, optional
         The function to use for combining points in the same bin. Defaults
         to np.nanmean.
-    start_time : `~astropy.time.Time`, optional
+    time_bin_start : `~astropy.time.Time`, optional
         The start time for the binned time series. Defaults to the first
         time in the sampled time series.
     n_bins : int, optional
@@ -49,17 +49,17 @@ def simple_downsample(time_series, bin_size, func=None, start_time=None, n_bins=
     if not isinstance(time_series, TimeSeries):
         raise TypeError("time_series should be a TimeSeries")
 
-    bin_size_sec = bin_size.to_value(u.s)
+    bin_size_sec = time_bin_size.to_value(u.s)
 
     # Use the table sorted by time
     sorted = time_series.iloc[:]
 
     # Determine start time if needed
-    if start_time is None:
-        start_time = sorted.time[0]
+    if time_bin_start is None:
+        time_bin_start = sorted.time[0]
 
     # Find the relative time since the start time, in seconds
-    relative_time_sec = (sorted.time - start_time).sec
+    relative_time_sec = (sorted.time - time_bin_start).sec
 
     # Determine the number of bins if needed
     if n_bins is None:
@@ -70,7 +70,7 @@ def simple_downsample(time_series, bin_size, func=None, start_time=None, n_bins=
 
     # Determine the bins
     relative_bins_sec = np.cumsum(np.hstack([0, np.repeat(bin_size_sec, n_bins)]))
-    bins = start_time + relative_bins_sec * u.s
+    bins = time_bin_start + relative_bins_sec * u.s
 
     # Find the subset of the table that is inside the bins
     keep = ((relative_time_sec >= relative_bins_sec[0]) &
@@ -82,7 +82,7 @@ def simple_downsample(time_series, bin_size, func=None, start_time=None, n_bins=
     indices = np.searchsorted(relative_bins_sec, relative_time_sec[keep]) - 1
 
     # Create new binned time series
-    binned = BinnedTimeSeries(start_time=bins[:-1], end_time=bins[-1])
+    binned = BinnedTimeSeries(time_bin_start=bins[:-1], time_bin_end=bins[-1])
 
     # Determine rows where values are defined
     groups = np.hstack([0, np.nonzero(np.diff(indices))[0] + 1])

--- a/astropy_timeseries/sampled.py
+++ b/astropy_timeseries/sampled.py
@@ -90,6 +90,9 @@ class TimeSeries(BaseTimeSeries):
 
     @property
     def time(self):
+        """
+        The time values.
+        """
         return self['time']
 
     def fold(self, period=None, midpoint_epoch=None):

--- a/astropy_timeseries/tests/test_binned.py
+++ b/astropy_timeseries/tests/test_binned.py
@@ -16,7 +16,7 @@ PLAIN_TABLE = Table([[1, 2, 11], [3, 4, 1], [1, 1, 1]], names=['a', 'b', 'c'])
 
 def test_empty_initialization():
     ts = BinnedTimeSeries()
-    ts['start_time'] = Time([1, 2, 3], format='mjd')
+    ts['time_bin_start'] = Time([1, 2, 3], format='mjd')
 
 
 def test_empty_initialization_invalid():
@@ -27,7 +27,7 @@ def test_empty_initialization_invalid():
     with pytest.raises(ValueError) as exc:
         ts['flux'] = [1, 2, 3]
     assert exc.value.args[0] == ("BinnedTimeSeries requires a column called "
-                                 "'start_time' to be set before data can be added")
+                                 "'time_bin_start' to be set before data can be added")
 
 
 def test_even_contiguous():
@@ -35,14 +35,20 @@ def test_even_contiguous():
     # Initialize a ``BinnedTimeSeries`` with even contiguous bins by specifying
     # the bin width:
 
-    ts = BinnedTimeSeries(start_time='2016-03-22T12:30:31',
-                          bin_size=3 * u.s, data=[[1, 4, 3]])
-    assert_equal(ts.start_time.isot, ['2016-03-22T12:30:31.000',
-                                      '2016-03-22T12:30:34.000',
-                                      '2016-03-22T12:30:37.000'])
-    assert_equal(ts.end_time.isot, ['2016-03-22T12:30:34.000',
-                                    '2016-03-22T12:30:37.000',
-                                    '2016-03-22T12:30:40.000'])
+    ts = BinnedTimeSeries(time_bin_start='2016-03-22T12:30:31',
+                          time_bin_size=3 * u.s, data=[[1, 4, 3]])
+
+    assert_equal(ts.time_bin_start.isot, ['2016-03-22T12:30:31.000',
+                                          '2016-03-22T12:30:34.000',
+                                          '2016-03-22T12:30:37.000'])
+
+    assert_equal(ts.time_bin_center.isot, ['2016-03-22T12:30:32.500',
+                                           '2016-03-22T12:30:35.500',
+                                           '2016-03-22T12:30:38.500'])
+
+    assert_equal(ts.time_bin_end.isot, ['2016-03-22T12:30:34.000',
+                                        '2016-03-22T12:30:37.000',
+                                        '2016-03-22T12:30:40.000'])
 
 
 def test_uneven_contiguous():
@@ -50,17 +56,23 @@ def test_uneven_contiguous():
     # Initialize a ``BinnedTimeSeries`` with uneven contiguous bins by giving an
     # end time:
 
-    ts = BinnedTimeSeries(start_time=['2016-03-22T12:30:31',
-                                      '2016-03-22T12:30:32',
-                                      '2016-03-22T12:30:40'],
-                          end_time='2016-03-22T12:30:55',
+    ts = BinnedTimeSeries(time_bin_start=['2016-03-22T12:30:31',
+                                          '2016-03-22T12:30:32',
+                                          '2016-03-22T12:30:40'],
+                          time_bin_end='2016-03-22T12:30:55',
                           data=[[1, 4, 3]])
-    assert_equal(ts.start_time.isot, ['2016-03-22T12:30:31.000',
-                                      '2016-03-22T12:30:32.000',
-                                      '2016-03-22T12:30:40.000'])
-    assert_equal(ts.end_time.isot, ['2016-03-22T12:30:32.000',
-                                    '2016-03-22T12:30:40.000',
-                                    '2016-03-22T12:30:55.000'])
+
+    assert_equal(ts.time_bin_start.isot, ['2016-03-22T12:30:31.000',
+                                          '2016-03-22T12:30:32.000',
+                                          '2016-03-22T12:30:40.000'])
+
+    assert_equal(ts.time_bin_center.isot, ['2016-03-22T12:30:31.500',
+                                           '2016-03-22T12:30:36.000',
+                                           '2016-03-22T12:30:47.500'])
+
+    assert_equal(ts.time_bin_end.isot, ['2016-03-22T12:30:32.000',
+                                        '2016-03-22T12:30:40.000',
+                                        '2016-03-22T12:30:55.000'])
 
 
 def test_uneven_non_contiguous():
@@ -68,17 +80,23 @@ def test_uneven_non_contiguous():
     # Initialize a ``BinnedTimeSeries`` with uneven non-contiguous bins with
     # lists of start times, bin sizes and data:
 
-    ts = BinnedTimeSeries(start_time=['2016-03-22T12:30:31',
-                                      '2016-03-22T12:30:38',
-                                      '2016-03-22T12:34:40'],
-                          bin_size=[5, 100, 2]*u.s,
+    ts = BinnedTimeSeries(time_bin_start=['2016-03-22T12:30:31',
+                                          '2016-03-22T12:30:38',
+                                          '2016-03-22T12:34:40'],
+                          time_bin_size=[5, 100, 2]*u.s,
                           data=[[1, 4, 3]])
-    assert_equal(ts.start_time.isot, ['2016-03-22T12:30:31.000',
-                                      '2016-03-22T12:30:38.000',
-                                      '2016-03-22T12:34:40.000'])
-    assert_equal(ts.end_time.isot, ['2016-03-22T12:30:36.000',
-                                    '2016-03-22T12:32:18.000',
-                                    '2016-03-22T12:34:42.000'])
+
+    assert_equal(ts.time_bin_start.isot, ['2016-03-22T12:30:31.000',
+                                          '2016-03-22T12:30:38.000',
+                                          '2016-03-22T12:34:40.000'])
+
+    assert_equal(ts.time_bin_center.isot, ['2016-03-22T12:30:33.500',
+                                           '2016-03-22T12:31:28.000',
+                                           '2016-03-22T12:34:41.000'])
+
+    assert_equal(ts.time_bin_end.isot, ['2016-03-22T12:30:36.000',
+                                        '2016-03-22T12:32:18.000',
+                                        '2016-03-22T12:34:42.000'])
 
 
 def test_uneven_non_contiguous_full():
@@ -86,18 +104,22 @@ def test_uneven_non_contiguous_full():
     # Initialize a ``BinnedTimeSeries`` with uneven non-contiguous bins by
     # specifying the start and end times for the bins:
 
-    ts = BinnedTimeSeries(start_time=['2016-03-22T12:30:31',
-                                      '2016-03-22T12:30:33',
-                                      '2016-03-22T12:30:40'],
-                          end_time=['2016-03-22T12:30:32',
-                                    '2016-03-22T12:30:35',
-                                    '2016-03-22T12:30:41'],
+    ts = BinnedTimeSeries(time_bin_start=['2016-03-22T12:30:31',
+                                          '2016-03-22T12:30:33',
+                                          '2016-03-22T12:30:40'],
+                          time_bin_end=['2016-03-22T12:30:32',
+                                        '2016-03-22T12:30:35',
+                                        '2016-03-22T12:30:41'],
                           data=[[1, 4, 3]])
 
-    assert_equal(ts.start_time.isot, ['2016-03-22T12:30:31.000',
-                                      '2016-03-22T12:30:33.000',
-                                      '2016-03-22T12:30:40.000'])
+    assert_equal(ts.time_bin_start.isot, ['2016-03-22T12:30:31.000',
+                                          '2016-03-22T12:30:33.000',
+                                          '2016-03-22T12:30:40.000'])
 
-    assert_equal(ts.end_time.isot, ['2016-03-22T12:30:32.000',
-                                    '2016-03-22T12:30:35.000',
-                                    '2016-03-22T12:30:41.000'])
+    assert_equal(ts.time_bin_center.isot, ['2016-03-22T12:30:31.500',
+                                           '2016-03-22T12:30:34.000',
+                                           '2016-03-22T12:30:40.500'])
+
+    assert_equal(ts.time_bin_end.isot, ['2016-03-22T12:30:32.000',
+                                        '2016-03-22T12:30:35.000',
+                                        '2016-03-22T12:30:41.000'])

--- a/astropy_timeseries/tests/test_common.py
+++ b/astropy_timeseries/tests/test_common.py
@@ -56,12 +56,15 @@ class TestTimeSeries(CommonTimeSeriesTests):
 
 class TestBinnedTimeSeries(CommonTimeSeriesTests):
 
-    _row = {'start_time': '2016-03-22T12:30:40', 'bin_size': 2 * u.s, 'a': 1., 'b': 2, 'c': 'a'}
+    _row = {'time_bin_start': '2016-03-22T12:30:40',
+            'time_bin_size': 2 * u.s, 'a': 1., 'b': 2, 'c': 'a'}
 
     def setup_method(self, method):
-        self.series = BinnedTimeSeries(start_time=INPUT_TIME, bin_size=3 * u.s, data=PLAIN_TABLE)
-        self.time_attr = 'start_time'
+        self.series = BinnedTimeSeries(time_bin_start=INPUT_TIME,
+                                       time_bin_size=3 * u.s,
+                                       data=PLAIN_TABLE)
+        self.time_attr = 'time_bin_start'
 
     def test_column_slicing(self):
-        ts = self.series['start_time', 'bin_size', 'a']
+        ts = self.series['time_bin_start', 'time_bin_size', 'a']
         assert isinstance(ts, BinnedTimeSeries)

--- a/docs/timeseries/analysis.rst
+++ b/docs/timeseries/analysis.rst
@@ -130,7 +130,7 @@ downsample using:
     import numpy as np
     from astropy import units as u
     from astropy_timeseries import simple_downsample
-    kepler_binned = simple_downsample(kepler, bin_size=20 * u.min, func=np.nanmedian)
+    kepler_binned = simple_downsample(kepler, time_bin_size=20 * u.min, func=np.nanmedian)
 
 We can take a look at the results:
 
@@ -140,7 +140,7 @@ We can take a look at the results:
 
     import matplotlib.pyplot as plt
     plt.plot(kepler.time.jd, kepler['sap_flux'], 'k.', markersize=1)
-    plt.plot(kepler_binned.start_time.jd, kepler_binned['sap_flux'], 'r-', drawstyle='steps-pre')
+    plt.plot(kepler_binned.time_bin_start.jd, kepler_binned['sap_flux'], 'r-', drawstyle='steps-pre')
     plt.xlabel('Barycentric Julian Date')
     plt.ylabel('SAP Flux (e-/s)')
 

--- a/docs/timeseries/data_access.rst
+++ b/docs/timeseries/data_access.rst
@@ -96,7 +96,7 @@ For |BinnedTimeSeries|, we provide three attributes: |time_bin_start|,
 
 In addition, the |time_bin_size| attribute can be used to access the bin sizes::
 
-    >>> bts.time_bin_size
+    >>> bts.time_bin_size  # doctest: +SKIP
     <Quantity [3., 3., 3., 3., 3.] s>
 
 Note that only |time_bin_start| and |time_bin_size| are available as actual

--- a/docs/timeseries/data_access.rst
+++ b/docs/timeseries/data_access.rst
@@ -8,6 +8,11 @@ Accessing data in time series
 .. |QTable| replace:: :class:`~astropy.table.QTable`
 .. |TimeSeries| replace:: :class:`~astropy_timeseries.TimeSeries`
 .. |BinnedTimeSeries| replace:: :class:`~astropy_timeseries.BinnedTimeSeries`
+.. |time_attr| replace:: :attr:`~astropy_timeseries.TimeSeries.time`
+.. |time_bin_start| replace:: :attr:`~astropy_timeseries.BinnedTimeSeries.time_bin_start`
+.. |time_bin_center| replace:: :attr:`~astropy_timeseries.BinnedTimeSeries.time_bin_center`
+.. |time_bin_end| replace:: :attr:`~astropy_timeseries.BinnedTimeSeries.time_bin_end`
+.. |time_bin_size| replace:: :attr:`~astropy_timeseries.BinnedTimeSeries.time_bin_size`
 
 Accessing data
 ==============
@@ -63,15 +68,15 @@ Accessing times
 
 For |TimeSeries|, the ``time`` column can be accessed using the regular column
 access notation, as shown in `Accessing data`_, but they can also be accessed
-more conveniently using attribute notation::
+more conveniently using the |time_attr| attribute::
 
     >>> ts.time
     <Time object: scale='utc' format='isot' value=['2016-03-22T12:30:31.000' '2016-03-22T12:30:34.000'
      '2016-03-22T12:30:37.000' '2016-03-22T12:30:40.000'
      '2016-03-22T12:30:43.000']>
 
-For |BinnedTimeSeries|, we provide three attributes: ``time_bin_start``,
-``time_bin_center``, and ``time_bin_end``::
+For |BinnedTimeSeries|, we provide three attributes: |time_bin_start|,
+|time_bin_center|, and |time_bin_end|::
 
     >>> from astropy_timeseries import BinnedTimeSeries
     >>> bts = BinnedTimeSeries(time_bin_start='2016-03-22T12:30:31',
@@ -89,13 +94,13 @@ For |BinnedTimeSeries|, we provide three attributes: ``time_bin_start``,
      '2016-03-22T12:30:40.000' '2016-03-22T12:30:43.000'
      '2016-03-22T12:30:46.000']>
 
-In addition, the ``time_bin_size`` attribute can be used to access the bin sizes::
+In addition, the |time_bin_size| attribute can be used to access the bin sizes::
 
     >>> bts.time_bin_size
     <Quantity [3., 3., 3., 3., 3.] s>
 
-Note that only ``time_bin_start`` and ``time_bin_size`` are available as actual
-columns, and ``time_bin_center`` and ``time_bin_end`` are computed on-the-fly.
+Note that only |time_bin_start| and |time_bin_size| are available as actual
+columns, and |time_bin_center| and |time_bin_end| are computed on-the-fly.
 
 See :ref:`timeseries-times` for more information about changing between
 different representations of time.

--- a/docs/timeseries/data_access.rst
+++ b/docs/timeseries/data_access.rst
@@ -56,20 +56,49 @@ row, or vice-versa::
     >>> ts['temp'][2]
     39.0
 
+.. _timeseries-accessing-times:
+
 Accessing times
 ===============
 
-The ``time`` column (for |TimeSeries|) and the ``start_time`` column (for
-|BinnedTimeSeries|) can be accessed using the regular column access notation, as
-shown in `Accessing data`_, but they can also be accessed more conveniently
-using attribute notation::
+For |TimeSeries|, the ``time`` column can be accessed using the regular column
+access notation, as shown in `Accessing data`_, but they can also be accessed
+more conveniently using attribute notation::
 
     >>> ts.time
     <Time object: scale='utc' format='isot' value=['2016-03-22T12:30:31.000' '2016-03-22T12:30:34.000'
      '2016-03-22T12:30:37.000' '2016-03-22T12:30:40.000'
      '2016-03-22T12:30:43.000']>
 
-.. TODO: describe attributes on BinnedTimeSeries
+For |BinnedTimeSeries|, we provide three attributes: ``time_bin_start``,
+``time_bin_center``, and ``time_bin_end``::
+
+    >>> from astropy_timeseries import BinnedTimeSeries
+    >>> bts = BinnedTimeSeries(time_bin_start='2016-03-22T12:30:31',
+    ...                        time_bin_size=3 * u.s, n_bins=5)
+    >>> bts.time_bin_start
+    <Time object: scale='utc' format='isot' value=['2016-03-22T12:30:31.000' '2016-03-22T12:30:34.000'
+     '2016-03-22T12:30:37.000' '2016-03-22T12:30:40.000'
+     '2016-03-22T12:30:43.000']>
+    >>> bts.time_bin_center
+    <Time object: scale='utc' format='isot' value=['2016-03-22T12:30:32.500' '2016-03-22T12:30:35.500'
+     '2016-03-22T12:30:38.500' '2016-03-22T12:30:41.500'
+     '2016-03-22T12:30:44.500']>
+    >>> bts.time_bin_end
+    <Time object: scale='utc' format='isot' value=['2016-03-22T12:30:34.000' '2016-03-22T12:30:37.000'
+     '2016-03-22T12:30:40.000' '2016-03-22T12:30:43.000'
+     '2016-03-22T12:30:46.000']>
+
+In addition, the ``time_bin_size`` attribute can be used to access the bin sizes::
+
+    >>> bts.time_bin_size
+    <Quantity [3., 3., 3., 3., 3.] s>
+
+Note that only ``time_bin_start`` and ``time_bin_size`` are available as actual
+columns, and ``time_bin_center`` and ``time_bin_end`` are computed on-the-fly.
+
+See :ref:`timeseries-times` for more information about changing between
+different representations of time.
 
 Extracting a subset of columns
 ==============================

--- a/docs/timeseries/index.rst
+++ b/docs/timeseries/index.rst
@@ -209,7 +209,7 @@ time - this returns a |BinnedTimeSeries|::
     >>> ts_binned = simple_downsample(ts_folded, 0.03 * u.day)  # doctest: +REMOTE_DATA
     >>> ts_binned  # doctest: +FLOAT_CMP +REMOTE_DATA
     <BinnedTimeSeries length=74>
-         start_time          bin_size      ...   pos_corr2    sap_flux_norm
+      time_bin_start      time_bin_size    ...   pos_corr2    sap_flux_norm
                                 s          ...
            object            float64       ...    float32        float32
     ------------------- ------------------ ... -------------- -------------
@@ -254,7 +254,7 @@ Let's take a look at the final result:
    :include-source:
 
    plt.plot(ts_folded.time.jd, ts_folded['sap_flux_norm'], 'k.', markersize=1)
-   plt.plot(ts_binned.start_time.jd, ts_binned['sap_flux_norm'], 'r-', drawstyle='steps-post')
+   plt.plot(ts_binned.time_bin_start.jd, ts_binned['sap_flux_norm'], 'r-', drawstyle='steps-post')
    plt.xlabel('Time (days)')
    plt.ylabel('Normalized flux')
 

--- a/docs/timeseries/initializing.rst
+++ b/docs/timeseries/initializing.rst
@@ -98,24 +98,24 @@ To create a binned time series with equal-size contiguous bins, it is sufficient
 to specify a start time as well as a bin size::
 
     >>> from astropy_timeseries import BinnedTimeSeries
-    >>> ts3 = BinnedTimeSeries(start_time='2016-03-22T12:30:31',
-    ...                        bin_size=3 * u.s, n_bins=10)
+    >>> ts3 = BinnedTimeSeries(time_bin_start='2016-03-22T12:30:31',
+    ...                        time_bin_size=3 * u.s, n_bins=10)
     >>> ts3
     <BinnedTimeSeries length=10>
-        start_time       bin_size
-                            s
-          object         float64
-    ----------------------- --------
-    2016-03-22T12:30:31.000      3.0
-    2016-03-22T12:30:34.000      3.0
-    2016-03-22T12:30:37.000      3.0
-    2016-03-22T12:30:40.000      3.0
-    2016-03-22T12:30:43.000      3.0
-    2016-03-22T12:30:46.000      3.0
-    2016-03-22T12:30:49.000      3.0
-    2016-03-22T12:30:52.000      3.0
-    2016-03-22T12:30:55.000      3.0
-    2016-03-22T12:30:58.000      3.0
+        time_bin_start     time_bin_size
+                                 s
+            object            float64
+    ----------------------- -------------
+    2016-03-22T12:30:31.000           3.0
+    2016-03-22T12:30:34.000           3.0
+    2016-03-22T12:30:37.000           3.0
+    2016-03-22T12:30:40.000           3.0
+    2016-03-22T12:30:43.000           3.0
+    2016-03-22T12:30:46.000           3.0
+    2016-03-22T12:30:49.000           3.0
+    2016-03-22T12:30:52.000           3.0
+    2016-03-22T12:30:55.000           3.0
+    2016-03-22T12:30:58.000           3.0
 
 Note that the ``n_bins`` argument is only needed if you are not also passing in
 data during initialization (see `Passing data during initialization`_).
@@ -127,31 +127,31 @@ Creating a binned time series with uneven contiguous bins, the bin size can be
 changed to give multiple values (note that in this case ``n_bins`` is not
 required)::
 
-    >>> ts4 = BinnedTimeSeries(start_time='2016-03-22T12:30:31',
-    ...                        bin_size=[3, 3, 2, 3] * u.s)
+    >>> ts4 = BinnedTimeSeries(time_bin_start='2016-03-22T12:30:31',
+    ...                        time_bin_size=[3, 3, 2, 3] * u.s)
     >>> ts4
     <BinnedTimeSeries length=4>
-        start_time       bin_size
-                            s
-          object         float64
-    ----------------------- --------
-    2016-03-22T12:30:31.000      3.0
-    2016-03-22T12:30:34.000      3.0
-    2016-03-22T12:30:37.000      2.0
-    2016-03-22T12:30:39.000      3.0
+         time_bin_start     time_bin_size
+                                  s
+             object            float64
+    ----------------------- -------------
+    2016-03-22T12:30:31.000           3.0
+    2016-03-22T12:30:34.000           3.0
+    2016-03-22T12:30:37.000           2.0
+    2016-03-22T12:30:39.000           3.0
 
 Alternatively, you can create the same time series by giving an array of start
 times as well as a single end time::
 
 
-    >>> ts5 = BinnedTimeSeries(start_time=['2016-03-22T12:30:31',
+    >>> ts5 = BinnedTimeSeries(time_bin_start=['2016-03-22T12:30:31',
     ...                                    '2016-03-22T12:30:34',
     ...                                    '2016-03-22T12:30:37',
     ...                                    '2016-03-22T12:30:39'],
-    ...                        end_time='2016-03-22T12:30:42')
+    ...                        time_bin_end='2016-03-22T12:30:42')
     >>> ts5  # doctest: +FLOAT_CMP
     <BinnedTimeSeries length=4>
-        start_time            bin_size
+        time_bin_start            time_bin_size
                                  s
           object              float64
     ----------------------- -----------------
@@ -166,33 +166,32 @@ Uneven non-contiguous bins
 To create a binned time series with non-contiguous bins, you can either
 specify an array of start times and bin widths::
 
-    >>> ts6 = BinnedTimeSeries(start_time=['2016-03-22T12:30:31',
+    >>> ts6 = BinnedTimeSeries(time_bin_start=['2016-03-22T12:30:31',
     ...                                    '2016-03-22T12:30:38',
     ...                                    '2016-03-22T12:34:40'],
-    ...                        bin_size=[5, 100, 2]*u.s)
+    ...                        time_bin_size=[5, 100, 2]*u.s)
     >>> ts6
     <BinnedTimeSeries length=3>
-        start_time       bin_size
-                            s
-          object         float64
-    ----------------------- --------
-    2016-03-22T12:30:31.000      5.0
-    2016-03-22T12:30:38.000    100.0
-    2016-03-22T12:34:40.000      2.0
-
+         time_bin_start     time_bin_size
+                                  s
+             object            float64
+    ----------------------- -------------
+    2016-03-22T12:30:31.000           5.0
+    2016-03-22T12:30:38.000         100.0
+    2016-03-22T12:34:40.000           2.0
 
 Or in the most general case, you can also specify multiple times for
-``start_time`` and ``end_time``::
+``time_bin_start`` and ``time_bin_end``::
 
-    >>> ts7 = BinnedTimeSeries(start_time=['2016-03-22T12:30:31',
+    >>> ts7 = BinnedTimeSeries(time_bin_start=['2016-03-22T12:30:31',
     ...                                    '2016-03-22T12:30:33',
     ...                                    '2016-03-22T12:30:40'],
-    ...                        end_time=['2016-03-22T12:30:32',
+    ...                        time_bin_end=['2016-03-22T12:30:32',
     ...                                  '2016-03-22T12:30:35',
     ...                                  '2016-03-22T12:30:41'])
     >>> ts7  # doctest: +FLOAT_CMP
     <BinnedTimeSeries length=3>
-           start_time            bin_size
+        time_bin_start        time_bin_size
                                     s
              object              float64
     ----------------------- ------------------
@@ -235,15 +234,15 @@ Passing data during initialization
 It is also possible to pass the data during the initialization, as for
 |Table|, e.g.::
 
-    >>> ts8 = BinnedTimeSeries(start_time=['2016-03-22T12:30:31',
+    >>> ts8 = BinnedTimeSeries(time_bin_start=['2016-03-22T12:30:31',
     ...                                    '2016-03-22T12:30:34',
     ...                                    '2016-03-22T12:30:37',
     ...                                    '2016-03-22T12:30:39'],
-    ...                        end_time='2016-03-22T12:30:42',
+    ...                        time_bin_end='2016-03-22T12:30:42',
     ...                        data={'flux': [1., 4., 5., 6.] * u.mJy})
     >>> ts8  # doctest: +FLOAT_CMP
     <BinnedTimeSeries length=4>
-           start_time            bin_size       flux
+           time_bin_start            time_bin_size       flux
                                     s           mJy
              object              float64      float64
     ----------------------- ----------------- -------
@@ -259,12 +258,12 @@ Adding rows to |TimeSeries| or |BinnedTimeSeries| can be done using the
 :meth:`~astropy.table.Table.add_row` method, as for |Table| and |QTable|. This
 method takes a dictionary where the keys are column names::
 
-    >>> ts8.add_row({'start_time': '2016-03-22T12:30:44.000',
-    ...              'bin_size': 2 * u.s,
+    >>> ts8.add_row({'time_bin_start': '2016-03-22T12:30:44.000',
+    ...              'time_bin_size': 2 * u.s,
     ...              'flux': 3 * u.mJy})
     >>> ts8  # doctest: +FLOAT_CMP
     <BinnedTimeSeries length=5>
-           start_time            bin_size       flux
+        time_bin_start       time_bin_size      flux
                                     s           mJy
              object              float64      float64
     ----------------------- ----------------- -------

--- a/docs/timeseries/times.rst
+++ b/docs/timeseries/times.rst
@@ -5,6 +5,12 @@ Converting between different time representations
 
 .. |Time| replace:: :class:`~astropy.time.Time`
 .. |TimeDelta| replace:: :class:`~astropy.time.TimeDelta`
+.. |TimeSeries| replace:: :class:`~astropy_timeseries.TimeSeries`
+.. |BinnedTimeSeries| replace:: :class:`~astropy_timeseries.BinnedTimeSeries`
+
+In :ref:`timeseries-accessing-times`, we saw how to access the time
+columns/attributes of the |TimeSeries| and |BinnedTimeSeries| classes. Here we
+look in more detail at how to manipulate the resulting times.
 
 Converting times
 ================


### PR DESCRIPTION
This renames the time attributes on the binned time series to be ``time_bin_start``, ``time_bin_center``, and ``time_bin_end`` - otherwise ``start_time`` makes it sound like it could be the start time of the whole time series.