### PR TITLE
Astropy 3.1 and 3.2 support for {from,to}_pandas

### DIFF
--- a/astropy_timeseries/binned.py
+++ b/astropy_timeseries/binned.py
@@ -80,9 +80,7 @@ class BinnedTimeSeries(BaseTimeSeries):
                 raise TypeError("'time_bin_start' is scalar, so 'time_bin_size' is required")
 
             if time_bin_size.isscalar:
-
                 if data is not None:
-
                     if n_bins is not None:
                         if n_bins != len(self):
                             raise TypeError("'n_bins' has been given and it is not the "

--- a/astropy_timeseries/binned.py
+++ b/astropy_timeseries/binned.py
@@ -115,9 +115,6 @@ class BinnedTimeSeries(BaseTimeSeries):
                     times[-1] = time_bin_end
                     time_bin_end = times
                 time_bin_size = (time_bin_end - time_bin_start).sec * u.s
-            elif time_bin_size is None:
-                # I am not sure this is triggerable.
-                raise TypeError("Either 'time_bin_size' or 'time_bin_end' should be specified")
 
         self.add_column(time_bin_start, index=0, name='time_bin_start')
         self.add_index('time_bin_start')

--- a/astropy_timeseries/binned.py
+++ b/astropy_timeseries/binned.py
@@ -82,8 +82,13 @@ class BinnedTimeSeries(BaseTimeSeries):
             if time_bin_size.isscalar:
 
                 if data is not None:
-                    # TODO: raise error if also passed explicily and inconsistent
-                    n_bins = len(self)
+
+                    if n_bins is not None:
+                        if n_bins != len(self):
+                            raise TypeError("'n_bins' has been given and it is not the "
+                                            "same length as the input data.")
+                    else:
+                        n_bins = len(self)
 
                 time_bin_size = np.repeat(time_bin_size, n_bins)
 
@@ -111,6 +116,7 @@ class BinnedTimeSeries(BaseTimeSeries):
                     time_bin_end = times
                 time_bin_size = (time_bin_end - time_bin_start).sec * u.s
             elif time_bin_size is None:
+                # I am not sure this is triggerable.
                 raise TypeError("Either 'time_bin_size' or 'time_bin_end' should be specified")
 
         self.add_column(time_bin_start, index=0, name='time_bin_start')

--- a/astropy_timeseries/sampled.py
+++ b/astropy_timeseries/sampled.py
@@ -40,8 +40,12 @@ class TimeSeries(BaseTimeSeries):
         # and treat it as if it had been passed as a keyword argument.
 
         if data is not None:
-            # TODO: raise error if also passed explicily and inconsistent
-            n_samples = len(self)
+            if n_samples is not None:
+                if n_samples != len(self):
+                    raise TypeError("'n_samples' has been given both and it is not the "
+                                    "same length as the input data.")
+            else:
+                n_samples = len(self)
 
         if 'time' in self.colnames:
             if time is None:

--- a/astropy_timeseries/sampled.py
+++ b/astropy_timeseries/sampled.py
@@ -94,7 +94,6 @@ class TimeSeries(BaseTimeSeries):
                                 "'time' is an array")
 
         self.add_column(time, index=0, name='time')
-        self.add_index('time')
 
     @property
     def time(self):
@@ -152,7 +151,7 @@ class TimeSeries(BaseTimeSeries):
         return result
 
     @classmethod
-    def from_pandas(self, df, index=False):
+    def from_pandas(self, df, time_scale='utc'):
         """
         Convert a :class:`~pandas.DataFrame` to a
         :class:`astropy_timeseries.TimeSeries`.
@@ -160,10 +159,10 @@ class TimeSeries(BaseTimeSeries):
         Parameters
         ----------
         df : :class:`pandas.DataFrame`
-            A pandas :class:`pandas.DataFrame` instance
-        index : bool, optional
-            Include the index column in the returned TimeSeries (default=False)
-            Only used if Astropy version >=``3.2``.
+            A pandas :class:`pandas.DataFrame` instance.
+        time_scale : str
+            The time scale to pass into `astropy.time.Time`.
+            Defaults to ``UTC``.
 
         """
         from pandas import DataFrame, DatetimeIndex
@@ -174,33 +173,15 @@ class TimeSeries(BaseTimeSeries):
         if not isinstance(df.index, DatetimeIndex):
             raise TypeError("DataFrame does not have a DatetimeIndex")
 
-        # TODO: determine how user can specify time scale
-        time = Time(df.index)
-
-        if ASTROPY_LT_32:
-            table = Table.from_pandas(df)
-        else:
-            table = Table.from_pandas(df, index=index)
+        time = Time(df.index, scale=time_scale)
+        table = Table.from_pandas(df)
 
         return TimeSeries(time=time, data=table)
 
-    def to_pandas(self, index=None):
+    def to_pandas(self):
         """
         Convert this :class:`~astropy_timeseries.TimeSeries` to a
         :class:`~pandas.DataFrame` with a :class:`~pandas.DatetimeIndex` index.
-
-        Parameters
-        ----------
-        index : None, bool, str
-            Only used if Astropy version >=``3.2``.
-            Specify DataFrame index mode.
-
-            For the default ``None`` (``index=True`` also), an index will be
-            specified for the DataFrame if there is a primary key index on the
-            TimeSeries *and* if it corresponds to a single column.
-            If ``index=False`` then no DataFrame index will be specified.
-            If ``index`` is a string which corresponds to the the name of a
-            column in the table then that will be the DataFrame index.
 
         Returns
         -------
@@ -208,16 +189,13 @@ class TimeSeries(BaseTimeSeries):
             A pandas :class:`pandas.DataFrame` instance
         """
 
-        # Extract table without time column
-        table = self[[x for x in self.colnames if x != 'time']]
-
-        # First make a normal pandas dataframe
         if ASTROPY_LT_32:
+            # Extract table without time column
+            table = self[[x for x in self.colnames if x != 'time']]
             df = Table(table).to_pandas()
+            # Set index
+            df.set_index(self.time.datetime64, inplace=True)
         else:
-            df = Table(table).to_pandas(index=index)
-
-        # Set index
-        df.set_index(self.time.datetime64, inplace=True)
+            df = Table(self).to_pandas(index='time')
 
         return df

--- a/astropy_timeseries/sampled.py
+++ b/astropy_timeseries/sampled.py
@@ -1,9 +1,11 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 
 from copy import deepcopy
+from distutils.version import LooseVersion
 
 import numpy as np
 
+import astropy
 from astropy.table import groups, QTable, Table
 from astropy.time import Time, TimeDelta
 from astropy import units as u
@@ -12,6 +14,8 @@ from astropy.units import Quantity
 from .core import BaseTimeSeries
 
 __all__ = ['TimeSeries']
+
+ASTROPY_LT_32 = LooseVersion(astropy.__version__) < LooseVersion("3.2")
 
 
 class TimeSeries(BaseTimeSeries):
@@ -144,12 +148,20 @@ class TimeSeries(BaseTimeSeries):
         return result
 
     @classmethod
-    def from_pandas(self, df):
+    def from_pandas(self, df, index=False):
         """
         Convert a :class:`~pandas.DataFrame` to a
         :class:`astropy_timeseries.TimeSeries`.
-        """
 
+        Parameters
+        ----------
+        df : :class:`pandas.DataFrame`
+            A pandas :class:`pandas.DataFrame` instance
+        index : bool, optional
+            Include the index column in the returned TimeSeries (default=False)
+            Only used if Astropy version >=``3.2``.
+
+        """
         from pandas import DataFrame, DatetimeIndex
 
         if not isinstance(df, DataFrame):
@@ -161,22 +173,45 @@ class TimeSeries(BaseTimeSeries):
         # TODO: determine how user can specify time scale
         time = Time(df.index)
 
-        # Create table without the time column
-        table = Table.from_pandas(df)
+        if ASTROPY_LT_32:
+            table = Table.from_pandas(df)
+        else:
+            table = Table.from_pandas(df, index=index)
 
         return TimeSeries(time=time, data=table)
 
-    def to_pandas(self):
+    def to_pandas(self, index=None):
         """
-        Convert this time series to a :class:`~pandas.DataFrame` with a
-        :class:`~pandas.DatetimeIndex` index.
+        Convert this :class:`~astropy_timeseries.TimeSeries` to a
+        :class:`~pandas.DataFrame` with a :class:`~pandas.DatetimeIndex` index.
+
+        Parameters
+        ----------
+        index : None, bool, str
+            Only used if Astropy version >=``3.2``.
+            Specify DataFrame index mode.
+
+            For the default ``None`` (``index=True`` also), an index will be
+            specified for the DataFrame if there is a primary key index on the
+            TimeSeries *and* if it corresponds to a single column.
+            If ``index=False`` then no DataFrame index will be specified.
+            If ``index`` is a string which corresponds to the the name of a
+            column in the table then that will be the DataFrame index.
+
+        Returns
+        -------
+        dataframe : :class:`pandas.DataFrame`
+            A pandas :class:`pandas.DataFrame` instance
         """
 
         # Extract table without time column
         table = self[[x for x in self.colnames if x != 'time']]
 
         # First make a normal pandas dataframe
-        df = Table(table).to_pandas()
+        if ASTROPY_LT_32:
+            df = Table(table).to_pandas()
+        else:
+            df = Table(table).to_pandas(index=index)
 
         # Set index
         df.set_index(self.time.datetime64, inplace=True)

--- a/astropy_timeseries/tests/test_sampled.py
+++ b/astropy_timeseries/tests/test_sampled.py
@@ -1,13 +1,11 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 
-from unittest import mock
 from datetime import datetime
 
 import pytest
 
 from numpy.testing import assert_equal, assert_allclose
 
-import astropy
 from astropy.table import Table
 from astropy.time import Time, TimeDelta
 from astropy import units as u
@@ -159,18 +157,16 @@ def test_pandas():
     ts = TimeSeries.from_pandas(df1)
     assert_equal(ts.time.isot, INPUT_TIME.isot)
     assert ts.colnames == ['time', 'a']
+    assert len(ts.indices) == 1
+    assert (ts.indices['time'].columns[0] == INPUT_TIME).all()
 
-    ts1 = TimeSeries.from_pandas(df1, index=True)
-    assert_equal(ts1.time.isot, INPUT_TIME.isot)
-    assert ts1.colnames == ['time', 'index', 'a']
+    ts_tcb = TimeSeries.from_pandas(df1, time_scale='tcb')
+    assert ts_tcb.time.scale == 'tcb'
 
     df2 = ts.to_pandas()
-    assert_equal(df2.index, INPUT_TIME.datetime64)
+    assert (df2.index.values == pandas.Index(INPUT_TIME.datetime64).values).all()
     assert df2.columns == pandas.Index(['a'])
-
-    df3 = ts.to_pandas(index='a')
-    assert_equal(df3.index, INPUT_TIME.datetime64)
-    assert len(df3.columns) == 0
+    assert (df1['a'] == df2['a']).all()
 
     with pytest.raises(TypeError) as exc:
         TimeSeries.from_pandas(None)

--- a/astropy_timeseries/tests/test_sampled.py
+++ b/astropy_timeseries/tests/test_sampled.py
@@ -160,7 +160,7 @@ def test_pandas():
     assert_equal(ts.time.isot, INPUT_TIME.isot)
     assert ts.colnames == ['time', 'a']
 
-    ts1 = TimeSeries.from_pandas(df1, index='a')
+    ts1 = TimeSeries.from_pandas(df1, index=True)
     assert_equal(ts1.time.isot, INPUT_TIME.isot)
     assert ts1.colnames == ['time', 'index', 'a']
 


### PR DESCRIPTION
Not quite sure its the idea you had in mind but let's start here. 

I went ahead and reverted the commit for 3.1. But I added another Travis Job for astropy stable. I wasn't sure if I should reduce the travis jobs to just check for astropy stable and dev.

Closes #14